### PR TITLE
Add skip_tls_verify option

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -30,11 +30,7 @@ func goMailDaemonRecoverable(mc *config, rChan <-chan *http.Request) {
 
 func goMailDaemon(mc *config, rChan <-chan *http.Request) {
 	d := gomail.NewPlainDialer(mc.host, mc.port, mc.username, mc.password)
-	if mc.port == 587 {
-		d.TLSConfig = &tls.Config{
-			ServerName: mc.host, // host names must match between this one and the one requested in the cert.
-		}
-	}
+	d.TLSConfig = &tls.Config{ServerName: mc.host, InsecureSkipVerify: mc.skipTlsVerify}
 
 	var s gomail.SendCloser
 	var err error

--- a/daemon.go
+++ b/daemon.go
@@ -30,7 +30,17 @@ func goMailDaemonRecoverable(mc *config, rChan <-chan *http.Request) {
 
 func goMailDaemon(mc *config, rChan <-chan *http.Request) {
 	d := gomail.NewPlainDialer(mc.host, mc.port, mc.username, mc.password)
-	d.TLSConfig = &tls.Config{ServerName: mc.host, InsecureSkipVerify: mc.skipTlsVerify}
+	if mc.port == 587 {
+		d.TLSConfig = &tls.Config{
+			ServerName: mc.host, // host names must match between this one and the one requested in the cert.
+		}
+	}
+	if mc.skipTlsVerify {
+		if d.TLSConfig == nil {
+			d.TLSConfig = &tls.Config{}
+		}
+		d.TLSConfig.InsecureSkipVerify = true
+	}
 
 	var s gomail.SendCloser
 	var err error

--- a/setup.go
+++ b/setup.go
@@ -157,6 +157,8 @@ func parse(c *caddy.Controller) (mc *config, _ error) {
 					return nil, c.ArgErr()
 				}
 				mc.portRaw = c.Val()
+			case "skip_tls_verify":
+				mc.skipTlsVerify = true
 			case "ratelimit_interval":
 				if !c.NextArg() {
 					return nil, c.ArgErr()

--- a/setup_test.go
+++ b/setup_test.go
@@ -65,6 +65,7 @@ func TestSetupParse(t *testing.T) {
 				body            testdata/mail_tpl.html
 				host            127.0.0.1
 				port            25
+				skip_tls_verify
 			}`,
 			nil,
 			func() *config {
@@ -77,6 +78,7 @@ func TestSetupParse(t *testing.T) {
 				c.body = `testdata/mail_tpl.html`
 				c.host = "127.0.0.1"
 				c.portRaw = "25"
+				c.skipTlsVerify = true
 				return c
 			},
 		},


### PR DESCRIPTION
Adds the ability to skip TLS verification of the server's certificate chain and host name.