### PR TITLE
Added "from" option

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,6 +62,9 @@ type config struct {
 	// to /dev/null also logs errors.
 	maillog maillog.Logger
 
+	// from            sender_from@domain.email
+	from []string
+
 	// to              recipient_to@domain.email
 	to []string
 	// cc              recipient_cc1@domain.email, recipient_cc2@domain.email

--- a/message.go
+++ b/message.go
@@ -107,6 +107,11 @@ func (bm message) setNonPGPRecipients(gm *gomail.Message) {
 }
 
 func (bm message) setFrom(gm *gomail.Message) {
+	if bm.mc.from {
+		gm.SetAddressHeader("From", bm.r.PostFormValue("email"), n)
+		return
+	}
+
 	if n := strings.TrimSpace(bm.r.PostFormValue("name")); n != "" {
 		gm.SetAddressHeader("From", bm.r.PostFormValue("email"), n)
 		return

--- a/message.go
+++ b/message.go
@@ -108,7 +108,7 @@ func (bm message) setNonPGPRecipients(gm *gomail.Message) {
 
 func (bm message) setFrom(gm *gomail.Message) {
 	if bm.mc.from {
-		gm.SetAddressHeader("From", bm.r.PostFormValue("email"), n)
+		gm.SetAddressHeader("From", bm.mc.from)
 		return
 	}
 


### PR DESCRIPTION
I'm working on a project for a client and wanted to be able to set the from header in the config (Because when people put in a "from" : @gmail.com google flags it because they didn't send it).

Disclaimer: I know nothing about GO, I mostly use a few other languages, looks really cool though. I couldn't even test it because I didn't know how to setup all of the dependencies to run the tests.

Hopefully it works and we can build it? If this is pushed how long does it take to get a build of caddy with the updated plugin?