### PR TITLE
Add support for URL redirection on form submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ mailout [endpoint] {
 	
 	[skip_tls_verify]
 	
+        [redirect_field "optional name of form field used for redirection url"]
+
 	[captcha]
 	
 	[recaptcha]
@@ -81,6 +83,7 @@ time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Default: 24h
 - `ratelimit_capacity`: the overall capacity within the interval. Default: 1000
 - `skip_tls_verify` if added skips the TLS verification process otherwise
 hostnames must match.
+- `redirect_field`: Form field name to use to configure redirection URL.
 
 The default filename for an encrypted message attached to an email is:
 *encrypted.gpg*.
@@ -281,6 +284,10 @@ Optional field should be `name`: `<input type="text" name="name" value=""/>`
 Both fields will be merged to the `From` Email address: `"name" <email@address>`.
 
 If you do not provide the name field, only the email address will be used.
+
+If a `redirect_field` has been configured and the form contains a matching
+field, its value will be used to redirect the user's browser after successful
+form submission.
 
 ### GMail
 

--- a/config.go
+++ b/config.go
@@ -97,6 +97,9 @@ type config struct {
 	//skip tls verify
 	skipTLSVerify bool
 
+	// specify form field used for redirect urls
+	redirectField string
+
 	// enable captcha
 	Captcha bool
 

--- a/serve.go
+++ b/serve.go
@@ -185,6 +185,15 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (_ int, err 
 	if h.reqPipe != nil {
 		h.reqPipe <- r // might block if the mail daemon is busy
 	}
+
+	// redirection
+	if h.config.redirectField != "" {
+		target := r.PostFormValue(h.config.redirectField)
+		if target != "" {
+			http.Redirect(w, r, target, http.StatusSeeOther)
+		}
+	}
+
 	return h.writeJSON(JSONError{Code: http.StatusOK}, w)
 }
 

--- a/setup.go
+++ b/setup.go
@@ -169,6 +169,11 @@ func parse(c *caddy.Controller) (mc *config, _ error) {
 				mc.portRaw = c.Val()
 			case "skip_tls_verify":
 				mc.skipTLSVerify = true
+			case "redirect_field":
+				if !c.NextArg() {
+					return nil, c.ArgErr()
+				}
+				mc.redirectField = c.Val()
 			case "captcha":
 				mc.Captcha = true
 			case "recaptcha":


### PR DESCRIPTION
The `redirect_field` config option can be used to specify the name of a (hidden) form field, which may then contain a URL to redirect to after successful form submission.

Closes #10.