### PR TITLE
New caddy import path

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/config_test.go
+++ b/config_test.go
@@ -144,7 +144,7 @@ func TestConfigLoadPGPKeyHDD(t *testing.T) {
 			`mailout {
 				go@ogle.com testdata/B06469EE_nopw.priv.asc
 			}`,
-			errors.New("[mailout] Cannot load PGP key for email address \"go@ogle.com\" with error: [mailout] PrivateKey found. Not allowed. Please remove it from resouce: \"testdata/B06469EE_nopw.priv.asc\""),
+			errors.New("[mailout] Cannot load PGP key for email address \"go@ogle.com\" with error: [mailout] PrivateKey found. Not allowed. Please remove it from resource: \"testdata/B06469EE_nopw.priv.asc\""),
 			true,
 		},
 		{

--- a/message_test.go
+++ b/message_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/SchumacherFM/mailout/maillog"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/serve.go
+++ b/serve.go
@@ -11,7 +11,7 @@ import (
 	"github.com/SchumacherFM/mailout/bufpool"
 	"github.com/gorilla/sessions"
 	"github.com/juju/ratelimit"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"github.com/quasoft/memstore"
 	"github.com/steambap/captcha"
 )
@@ -204,7 +204,7 @@ func (h *handler) writeJSON(je JSONError, w http.ResponseWriter) (int, error) {
 
 	w.Header().Set(headerContentType, headerApplicationJSONUTF8)
 
-	// https://github.com/mholt/caddy/issues/637#issuecomment-189599332
+	// https://github.com/caddyserver/caddy/issues/637#issuecomment-189599332
 	w.WriteHeader(je.Code)
 
 	if err := json.NewEncoder(buf).Encode(je); err != nil {

--- a/serve_test.go
+++ b/serve_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/setup.go
+++ b/setup.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/SchumacherFM/mailout/maillog"
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 )
 
 func init() {

--- a/setup_test.go
+++ b/setup_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
PR switches to the new import path for caddy.

I have not worked with `go` in a while. The move also generated `go.mod` and `go.sum` files. Do you want them to be included too?